### PR TITLE
Made Car & Fuel type Filter Menu Functional 

### DIFF
--- a/app/cars/page.tsx
+++ b/app/cars/page.tsx
@@ -12,6 +12,11 @@ import MobileScheduleBar from "@/components/MobileScheduleBar";
 import { useMediaQuery } from "react-responsive";
 import CarsPagination from "@/components/CarsPagination";
 
+interface ActiveFilters {
+  brands: string[];
+  car_types: string[];
+}
+
 const Cars = () => {
   // Storing all cars data in useState
   const [data, setData] = useState([]);
@@ -56,18 +61,33 @@ const Cars = () => {
 
   // Filter menus
   // All filter selected values
-  const [selectedFilters, setSelectedFilters] = useState<string | string[]>([]);
+  const [activeFilters, setActiveFilters] = useState<ActiveFilters>({
+    brands: [],
+    car_types: [],
+  });
+
+  const applyFilters = () => {
+    let result = data;
+
+    if (activeFilters.brands.length) {
+      result = result.filter((car: any) =>
+        activeFilters.brands.includes(car.brand)
+      );
+    }
+
+    if (activeFilters.car_types.length) {
+      result = result.filter((car: any) =>
+        activeFilters.car_types.includes(car.car_type)
+      );
+    }
+
+    setCars(result);
+  };
 
   // Run the filter function everytime new brand is selected
   useEffect(() => {
-    const filteredCars = data.filter(
-      (car: any) =>
-        selectedFilters.length == 0 ||
-        selectedFilters.includes(car.brand) ||
-        selectedFilters.includes(car.car_type)
-    );
-    setCars(filteredCars);
-  }, [data, selectedFilters, setCars]);
+    applyFilters();
+  }, [data, activeFilters]);
 
   return (
     <div>
@@ -113,8 +133,8 @@ const Cars = () => {
                 allCars={cars}
                 setCars={setCars}
                 data={data}
-                selectedFilters={selectedFilters}
-                setSelectedFilters={setSelectedFilters}
+                activeFilters={activeFilters}
+                setActiveFilters={setActiveFilters}
               />
             </li>
             <li>
@@ -123,8 +143,8 @@ const Cars = () => {
                 allCars={cars}
                 setCars={setCars}
                 data={data}
-                selectedFilters={selectedFilters}
-                setSelectedFilters={setSelectedFilters}
+                activeFilters={activeFilters}
+                setActiveFilters={setActiveFilters}
               />
             </li>
             <li>

--- a/app/cars/page.tsx
+++ b/app/cars/page.tsx
@@ -54,6 +54,21 @@ const Cars = () => {
     totalPages = Math.ceil(cars.length / cardsPerPage);
   }, [cars, currentPage]);
 
+  // Filter menus
+  // All filter selected values
+  const [selectedFilters, setSelectedFilters] = useState<string | string[]>([]);
+
+  // Run the filter function everytime new brand is selected
+  useEffect(() => {
+    const filteredCars = data.filter(
+      (car: any) =>
+        selectedFilters.length == 0 ||
+        selectedFilters.includes(car.brand) ||
+        selectedFilters.includes(car.car_type)
+    );
+    setCars(filteredCars);
+  }, [data, selectedFilters, setCars]);
+
   return (
     <div>
       {/*---------------------------------------------MAIN CONTAINER----------------------------------------- */}
@@ -98,12 +113,18 @@ const Cars = () => {
                 allCars={cars}
                 setCars={setCars}
                 data={data}
-                c
+                selectedFilters={selectedFilters}
+                setSelectedFilters={setSelectedFilters}
               />
             </li>
             <li>
               <CarTypeFilter
                 carTypes={(data as any[]).map((obj) => obj.car_type)}
+                allCars={cars}
+                setCars={setCars}
+                data={data}
+                selectedFilters={selectedFilters}
+                setSelectedFilters={setSelectedFilters}
               />
             </li>
             <li>
@@ -133,7 +154,7 @@ const Cars = () => {
               ></CarCard>
             ))}
         </div>
-        
+
         {/*--------------------------------PAGINATION-------------------------------- */}
         <div className="col-span-3 place-items-center">
           <CarsPagination

--- a/app/cars/page.tsx
+++ b/app/cars/page.tsx
@@ -15,6 +15,7 @@ import CarsPagination from "@/components/CarsPagination";
 interface ActiveFilters {
   brands: string[];
   car_types: string[];
+  fuel_types: string[];
 }
 
 const Cars = () => {
@@ -64,6 +65,7 @@ const Cars = () => {
   const [activeFilters, setActiveFilters] = useState<ActiveFilters>({
     brands: [],
     car_types: [],
+    fuel_types: [],
   });
 
   const applyFilters = () => {
@@ -78,6 +80,12 @@ const Cars = () => {
     if (activeFilters.car_types.length) {
       result = result.filter((car: any) =>
         activeFilters.car_types.includes(car.car_type)
+      );
+    }
+
+    if (activeFilters.fuel_types.length) {
+      result = result.filter((car: any) =>
+        activeFilters.fuel_types.includes(car.fuel_type)
       );
     }
 
@@ -150,6 +158,11 @@ const Cars = () => {
             <li>
               <FuelTypeFilter
                 fuelTypes={(data as any[]).map((obj) => obj.fuel_type)}
+                allCars={cars}
+                setCars={setCars}
+                data={data}
+                activeFilters={activeFilters}
+                setActiveFilters={setActiveFilters}
               />
             </li>
           </ul>

--- a/app/cars/page.tsx
+++ b/app/cars/page.tsx
@@ -22,6 +22,8 @@ const Cars = () => {
   // Storing all cars data in useState
   const [data, setData] = useState([]);
   const [cars, setCars] = useState([]);
+
+  // Schedule menu's useState values
   const [location, setLocation] = useState("Set Location...");
   const [date, setDate] = useState([
     {
@@ -35,7 +37,7 @@ const Cars = () => {
   // Use media query to determine screen size
   const isMobile = useMediaQuery({ maxWidth: 640 });
 
-  // Fecth the all car data initially when the page is loaded
+  // Fetch all car data initially when the page is loaded
   useEffect(() => {
     fetch("/api/cars")
       .then((response) => response.json())
@@ -60,14 +62,14 @@ const Cars = () => {
     totalPages = Math.ceil(cars.length / cardsPerPage);
   }, [cars, currentPage]);
 
-  // Filter menus
-  // All filter selected values
+  // All filter menus selected items are store in activeFilters
   const [activeFilters, setActiveFilters] = useState<ActiveFilters>({
     brands: [],
     car_types: [],
     fuel_types: [],
   });
 
+  // Filters the displayed cars based on the chosen filters
   const applyFilters = () => {
     let result = data;
 
@@ -92,7 +94,7 @@ const Cars = () => {
     setCars(result);
   };
 
-  // Run the filter function everytime new brand is selected
+  // Run the applyfilter function everytime new filter option is selected
   useEffect(() => {
     applyFilters();
   }, [data, activeFilters]);
@@ -138,30 +140,18 @@ const Cars = () => {
             <li>
               <BrandFilter
                 allBrands={(data as any[]).map((obj) => obj.brand)}
-                allCars={cars}
-                setCars={setCars}
-                data={data}
-                activeFilters={activeFilters}
                 setActiveFilters={setActiveFilters}
               />
             </li>
             <li>
               <CarTypeFilter
                 carTypes={(data as any[]).map((obj) => obj.car_type)}
-                allCars={cars}
-                setCars={setCars}
-                data={data}
-                activeFilters={activeFilters}
                 setActiveFilters={setActiveFilters}
               />
             </li>
             <li>
               <FuelTypeFilter
                 fuelTypes={(data as any[]).map((obj) => obj.fuel_type)}
-                allCars={cars}
-                setCars={setCars}
-                data={data}
-                activeFilters={activeFilters}
                 setActiveFilters={setActiveFilters}
               />
             </li>

--- a/components/Filter Menus/BrandFilter.tsx
+++ b/components/Filter Menus/BrandFilter.tsx
@@ -10,27 +10,25 @@ import {
 } from "@chakra-ui/react";
 import { IoIosArrowDown as DropDown } from "react-icons/io";
 
-const BrandFilter = ({ allBrands, allCars, setCars, data }: any) => {
+const BrandFilter = ({
+  allBrands,
+  allCars,
+  setCars,
+  data,
+  selectedFilters,
+  setSelectedFilters,
+}: any) => {
   // Ensuring the filter options are unique and sorted beforehand
   const uniqueTypes = [...new Set(allBrands)] as string[];
   uniqueTypes.sort();
 
   // Use state for the selected types
-  const [selectedBrands, setSelectedBrands] = useState<string | string[]>([]);
+  // const [selectedBrands, setSelectedBrands] = useState<string | string[]>([]);
 
   // Whenever new brand is selected
   const handleTypeSelectionChange = (selectedValues: string | string[]) => {
-    setSelectedBrands(selectedValues);
+    setSelectedFilters(selectedValues);
   };
-  
-  // Run the filter function everytime new brand is selected
-  useEffect(() => {
-    const filteredBrands = data.filter(
-      (car: any) =>
-        selectedBrands.length == 0 || selectedBrands.includes(car.brand)
-    );
-    setCars(filteredBrands);
-  }, [data, selectedBrands, setCars]);
 
   return (
     <Menu closeOnSelect={false}>

--- a/components/Filter Menus/BrandFilter.tsx
+++ b/components/Filter Menus/BrandFilter.tsx
@@ -15,8 +15,8 @@ const BrandFilter = ({
   allCars,
   setCars,
   data,
-  selectedFilters,
-  setSelectedFilters,
+  activeFilters,
+  setActiveFilters,
 }: any) => {
   // Ensuring the filter options are unique and sorted beforehand
   const uniqueTypes = [...new Set(allBrands)] as string[];
@@ -27,7 +27,10 @@ const BrandFilter = ({
 
   // Whenever new brand is selected
   const handleTypeSelectionChange = (selectedValues: string | string[]) => {
-    setSelectedFilters(selectedValues);
+    setActiveFilters((prevFilters: any) => ({
+      ...prevFilters,
+      ["brands"]: selectedValues,
+    }));
   };
 
   return (

--- a/components/Filter Menus/BrandFilter.tsx
+++ b/components/Filter Menus/BrandFilter.tsx
@@ -12,10 +12,6 @@ import { IoIosArrowDown as DropDown } from "react-icons/io";
 
 const BrandFilter = ({
   allBrands,
-  allCars,
-  setCars,
-  data,
-  activeFilters,
   setActiveFilters,
 }: any) => {
   // Ensuring the filter options are unique and sorted beforehand

--- a/components/Filter Menus/CarTypeFilter.tsx
+++ b/components/Filter Menus/CarTypeFilter.tsx
@@ -15,8 +15,8 @@ const CarTypeFilter = ({
   allCars,
   setCars,
   data,
-  selectedFilters,
-  setSelectedFilters,
+  activeFilters,
+  setActiveFilters,
 }: any) => {
   // Ensuring the filter options are unique and sorted beforehand
   const uniqueTypes = [...new Set(carTypes)] as string[];
@@ -26,7 +26,10 @@ const CarTypeFilter = ({
   // const [selectedTypes, setSelectedTypes] = useState<string | string[]>([]);
 
   const handleTypeSelectionChange = (selectedValues: string | string[]) => {
-    setSelectedFilters(selectedValues);
+    setActiveFilters((prevFilters: any) => ({
+      ...prevFilters,
+      ["car_types"]: selectedValues,
+    }));
   };
 
   return (

--- a/components/Filter Menus/CarTypeFilter.tsx
+++ b/components/Filter Menus/CarTypeFilter.tsx
@@ -12,10 +12,6 @@ import { IoIosArrowDown as DropDown } from "react-icons/io";
 
 const CarTypeFilter = ({
   carTypes,
-  allCars,
-  setCars,
-  data,
-  activeFilters,
   setActiveFilters,
 }: any) => {
   // Ensuring the filter options are unique and sorted beforehand

--- a/components/Filter Menus/CarTypeFilter.tsx
+++ b/components/Filter Menus/CarTypeFilter.tsx
@@ -10,16 +10,23 @@ import {
 } from "@chakra-ui/react";
 import { IoIosArrowDown as DropDown } from "react-icons/io";
 
-const CarTypeFilter = ({ carTypes }: any) => {
+const CarTypeFilter = ({
+  carTypes,
+  allCars,
+  setCars,
+  data,
+  selectedFilters,
+  setSelectedFilters,
+}: any) => {
   // Ensuring the filter options are unique and sorted beforehand
   const uniqueTypes = [...new Set(carTypes)] as string[];
   uniqueTypes.sort();
 
   // Use state for the selected types
-  const [selectedTypes, setSelectedTypes] = useState<string | string[]>([]);
+  // const [selectedTypes, setSelectedTypes] = useState<string | string[]>([]);
 
   const handleTypeSelectionChange = (selectedValues: string | string[]) => {
-    setSelectedTypes(selectedValues);
+    setSelectedFilters(selectedValues);
   };
 
   return (

--- a/components/Filter Menus/FuelTypeFilter.tsx
+++ b/components/Filter Menus/FuelTypeFilter.tsx
@@ -10,7 +10,14 @@ import {
 } from "@chakra-ui/react";
 import { IoIosArrowDown as DropDown } from "react-icons/io";
 
-const FuelTypeFilter = ({ fuelTypes }: any) => {
+const FuelTypeFilter = ({
+  fuelTypes,
+  allCars,
+  setCars,
+  data,
+  activeFilters,
+  setActiveFilters,
+}: any) => {
   // Ensuring the filter options are unique and sorted beforehand
   const uniqueTypes = [...new Set(fuelTypes)] as string[];
   uniqueTypes.sort();
@@ -19,7 +26,10 @@ const FuelTypeFilter = ({ fuelTypes }: any) => {
   const [selectedTypes, setSelectedTypes] = useState<string | string[]>([]);
 
   const handleTypeSelectionChange = (selectedValues: string | string[]) => {
-    setSelectedTypes(selectedValues);
+    setActiveFilters((prevFilters: any) => ({
+      ...prevFilters,
+      ["fuel_types"]: selectedValues,
+    }));
   };
 
   return (

--- a/components/Filter Menus/FuelTypeFilter.tsx
+++ b/components/Filter Menus/FuelTypeFilter.tsx
@@ -12,10 +12,6 @@ import { IoIosArrowDown as DropDown } from "react-icons/io";
 
 const FuelTypeFilter = ({
   fuelTypes,
-  allCars,
-  setCars,
-  data,
-  activeFilters,
   setActiveFilters,
 }: any) => {
   // Ensuring the filter options are unique and sorted beforehand

--- a/types.ts
+++ b/types.ts
@@ -3,3 +3,5 @@ export type Links = {
   title: string;
   url: string;
 };
+
+


### PR DESCRIPTION
# Description
- Made the car and fuel type menu functional
- For all filter menus to work simultaneously, I created an active filter state in the parent
- All displayed cars are filtered based on the active filters, which contain chosen filter options (brands, types)
- Fixed the issue where selecting a filter option of car_types, gets rid of the filter option selected from brands menu

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots
### Desktop View 
Selected Car type as Minivan
![Functional Filter Menus](https://github.com/akshithP/rent-ryde/assets/72608430/a414596d-5292-4c32-8ddf-765e45a06b65)

### Mobile View
Selected fuel type as electric and brand Telsa
![Functional Filter Menu Mobile View](https://github.com/akshithP/rent-ryde/assets/72608430/c2332d21-c611-4fad-95c3-b1628f49555c)


# Checklist:
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
